### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 ## Description
-Trango self-hosted is a calling and file sharing solution that works over LAN (local area networks). It does not need to involve the internet for calling or file sharing. Ideal for offices, hotels, houses, restaurants, and any space where people use the same Public IP address or the same WiFi network. The package comes with a discovery server and a web app which can be deployed on the local machine and can be accessed from anywhere in the network.<br />
+Trango Self-hosted is a calling and file-sharing solution that works over LAN (local area networks). It does not need to involve the internet for calling or file sharing, so it's ideal for offices, hotels, houses, restaurants, and any space where people use the same Public IP address or the same WiFi network. The package includes a discovery server and a web app which can be deployed on the local machine and can be accessed from anywhere in the network.<br />
 Trango Web can be visited at https://web.trango.io . Please note that Trango is in beta. <br />
-**Note** Opensource selfhosted version is now compatible with Mobile and Desktop Apps.
+**Note** The open-source self-hosted version is now compatible with Mobile and Desktop Apps.
 
-The Following are the main features.
-- One to One and Group Audio/Video Calling.
+The main features are:
+- One-to-One and Group Audio/Video Calling.
 - File Transferring.
-- Ability to change auto-generated ID's.
+- Ability to change auto-generated IDs.
 - No Internet Involved.
 - Encrypted and Secure.
-- HD Calling quality.
+- HD quality for calling.
 
 ## Deployment
-The package can be deployed on a Linux machine also to provide more robust support a docker image is available on the docker hub.
+The package can be deployed on a Linux machine, also. To provide more robust support a docker image is available on Docker Hub.
 ### Linux Deployment
 #### Debian Prerequisites
 - ``` sudo apt update && sudo apt install -y libboost-all-dev libssl-dev g++ nginx python3.6 python3-pip curl``` <br />
@@ -23,9 +23,9 @@ The package can be deployed on a Linux machine also to provide more robust suppo
 - ``` curl -sL https://deb.nodesource.com/setup_12.x -o nodesource_setup.sh && bash nodesource_setup.sh && yum install -y nodejs``` <br />
 - ``` pip3 install flask_restful flask_cors psutil```
 #### Deployment
-The Following are the steps for deployment.
+Follow these for deployment:
 - Clone or download this repo into your system.
-- On Terminal run the following commands.
+- On Terminal run these commands:
   - ``` cd /path/to/this/repo/folder/ ```
   - ``` cd app/```
   - ``` npm i && npm run build```
@@ -42,12 +42,12 @@ The Following are the steps for deployment.
   - ``` ./WebSocketWS &```
   
 #### Docker Deployment (Windows/Linux).
-Install docker on your machine and follow the following steps.
-- Download the Trango Self-Hosted version docker image by executing the below command.
+Install docker on your machine and follow these steps:
+- Download the Trango Self-Hosted version docker image by this command:
   - ```sudo docker pull tak786/trango-self-hosted```
-- Run the Self-Hosted version by executing the following command.
+- Run the Self-Hosted version:
   - ```sudo docker container run -d -p 80:80 -p 443:443 --name trango tak786/trango-self-hosted```
-- Test it by accessing the IP address of the machine running Self-Hosted version on your browser.
+- Test it by accessing the IP address of the machine running the Self-Hosted version on your browser.
 
 ## Contributing
 
@@ -56,7 +56,7 @@ Contributions are what make the open-source community such an amazing place to l
 1. Fork the Project
 2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
 3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the Branch (`git push origin feature/AmazingFeature`)
+4. Push the Branch upstream (`git push origin feature/AmazingFeature`)
 5. Open a Pull Request
 
 ## License


### PR DESCRIPTION
 - we never pluralize with apostrophes.
 - 'the below command' is a fantastic example of adjective order violation.
 - let's just avoid 'the following', since it's going to trip us up later.  Lose 'the below' as well, for the same reason.
 - the word jumble in the Deployment section is maybe fixed, but the ambiguity required a leap of guesswork.
 - this is gonna need more work.